### PR TITLE
EscrowFactory entity is replaced with LaunchedEscrow entity 

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1,8 +1,7 @@
-type EscrowFactory @entity {
+type LaunchedEscrow @entity {
   id: ID!
-  count: BigInt!
   eip20: Bytes! # address
-  escrow: Bytes! # address
+  from: Bytes! # address
 }
 
 type ISEvent @entity {

--- a/src/mapping/escrowfactory.ts
+++ b/src/mapping/escrowfactory.ts
@@ -1,31 +1,15 @@
-import { BigInt } from "@graphprotocol/graph-ts"
-import {
-  EscrowFactory,
-  Launched
-} from "../generated/EscrowFactory/EscrowFactory"
-import { EscrowFactory } from "../generated/schema"
+import { Launched } from "../generated/EscrowFactory/EscrowFactory"
+import { LaunchedEscrow } from "../generated/schema"
 import { Escrow } from "../generated/templates"
 
 export function handleLaunched(event: Launched): void {
-  // Entities can be loaded from the store using a string ID; this ID
-  // needs to be unique across all entities of the same type
-  let entity = EscrowFactory.load(event.transaction.from.toHex())
 
   // Entities only exist after they have been saved to the store;
-  // `null` checks allow to create entities on demand
-  if (!entity) {
-    entity = new EscrowFactory(event.transaction.from.toHex())
-
-    // Entity fields can be set using simple assignments
-    entity.count = BigInt.fromI32(0)
-  }
-
-  // BigInt and BigDecimal math are supported
-  entity.count = entity.count + BigInt.fromI32(1)
+  let entity = new LaunchedEscrow(event.params.escrow.toHex())
 
   // Entity fields can be set based on event parameters
   entity.eip20 = event.params.eip20
-  entity.escrow = event.params.escrow
+  entity.from = event.transaction.from
 
   // Entities can be written to the store with `.save()`
   entity.save()


### PR DESCRIPTION
EscrowFactory entity is replaced with LaunchedEscrow entity in order to be able to track and show all created escrows in a human dashboard for polygon network.

_Note: This is a cherry-picked change already applied to the rinkeby_